### PR TITLE
Fix lap calculation in Chrono

### DIFF
--- a/assets/scripts/Chrono.js
+++ b/assets/scripts/Chrono.js
@@ -54,7 +54,8 @@ function toggleChrono() {
     lapSound.play();
   } else {
     if (intervalId === null) {
-      startTime = new Date().getTime() - (startTime - startTime);
+      // start the chrono and take previously elapsed time into account
+      startTime = new Date().getTime();
       intervalId = setInterval(chrono, 1);
       lapSound.play();
     }
@@ -88,8 +89,9 @@ function LapChrono() {
   if (isRunning) {
       const currentTime = new Date().getTime() - startTime + elapsedTime;
       const lapTime = currentTime - lastLapTime;
-      lapTimes.push(lapTime); 
-      updateLapDisplay(); 
+      lapTimes.push(lapTime);
+      lastLapTime = currentTime;
+      updateLapDisplay();
       lapSound.play();
   }
 }


### PR DESCRIPTION
## Summary
- fix start logic comment and simplify expression
- record last lap end time so lap durations are correct

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68445a07d2e0832787a73a6a14993670